### PR TITLE
add return type for getValue() to be compatible with parent

### DIFF
--- a/src/Controls/DateTimeControlPrototype.php
+++ b/src/Controls/DateTimeControlPrototype.php
@@ -63,11 +63,8 @@ abstract class DateTimeControlPrototype extends TextBase
 		);
 	}
 
-
-	/**
-	 * @return DateTimeImmutable|null
-	 */
-	public function getValue()
+	
+	public function getValue(): ?DateTimeImmutable
 	{
 		if ($this->value instanceof DateTimeImmutable) {
 			return $this->value;


### PR DESCRIPTION
add return type for `getValue(): ?DateTimeImmutable` to be compatible with parent `\Nette\Forms\Controls\TextBase::getValue(): mixed`